### PR TITLE
updated kallisto version in conda yml

### DIFF
--- a/conda/environments/cribbslab.yml
+++ b/conda/environments/cribbslab.yml
@@ -24,6 +24,7 @@ dependencies:
 - setuptools
 - six
 - sqlalchemy
+- kallisto=0.48.0
 # Misc dependencies
 - coreutils
 - nomkl


### PR DESCRIPTION
Kallisto version needs to be 0.48.0 for compatibility with JADE cluster